### PR TITLE
remove unnecessary deps to slim bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
     "apollo-link-context": "^1.0.19",
     "apollo-link-error": "^1.1.12",
     "apollo-link-http": "^1.5.16",
-    "loglevel": "^1.6.6",
     "node-fetch": "^2.6.0",
-    "typed-graphqlify": "^2.2.3",
-    "yarn": "^1.21.1"
+    "typed-graphqlify": "^2.2.3"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.11.2",

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -5,7 +5,6 @@ import { InMemoryCache, NormalizedCacheObject } from 'apollo-cache-inmemory'
 import { from, FetchResult } from 'apollo-link'
 import { setContext } from 'apollo-link-context'
 import { onError } from 'apollo-link-error'
-import Log from 'loglevel'
 import gql from 'graphql-tag'
 import { query, mutation } from 'typed-graphqlify'
 import { GraphQLError } from 'graphql'
@@ -36,12 +35,12 @@ function createLink(
         const errlog = `[GraphQL error: ${endpoint}]: Message: ${message}, Location: ${JSON.stringify(
           locations
         )}, Path: ${path}`
-        Log.error(errlog)
+        console.error(errlog)
       })
     }
     if (networkError) {
       const errlog = `[Network error]: ${networkError}`
-      Log.error(errlog)
+      console.error(errlog)
     }
   })
   return from([authMiddleware, errorLink, httpLink])

--- a/yarn.lock
+++ b/yarn.lock
@@ -4793,11 +4793,6 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loglevel@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.6.tgz#0ee6300cc058db6b3551fa1c4bf73b83bb771312"
-  integrity sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==
-
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -6927,7 +6922,7 @@ yargs@^14.2.0:
     y18n "^4.0.0"
     yargs-parser "^15.0.0"
 
-yarn@^1.15.0, yarn@^1.21.1:
+yarn@^1.15.0:
   version "1.21.1"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.21.1.tgz#1d5da01a9a03492dc4a5957befc1fd12da83d89c"
   integrity sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==


### PR DESCRIPTION
We should reduce our dependencies as possible. I don't think we should use `loglevel` dep internally as it can replaceable with `console.error`